### PR TITLE
Add continuous integration with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: android
+android:
+  components:
+    - build-tools-26.0.2
+    - android-26
+    - extra

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: android
 android:
   components:
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-23.0.2
+    - android-23
     - extra

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Quake Report App
+Quake Report App [![Travis Build Status](https://travis-ci.org/udacity/ud843-QuakeReport.svg?branch=master)](https://travis-ci.org/udacity/ud843-QuakeReport)
 ===================================
 
 This app displays a list of recent earthquakes in the world


### PR DESCRIPTION
Adds continuous integration with Travis CI. Travis is configured to use `gradlew build` with the Android SDK 23.

Travis CI needs to be [enabled](https://github.com/marketplace/travis-ci) on the GitHub Marketplace.